### PR TITLE
Show register time

### DIFF
--- a/src/elements/stats-table/stats-table.html
+++ b/src/elements/stats-table/stats-table.html
@@ -65,7 +65,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div class="cell name">{{item.tagName}}</div>
           <div class="cell">{{item.count}}</div>
           <stats-item item="[[item]]" metric="totalTime" stats="[[stats]]" all-tags-stats="[[allTagsStats]]" class="total"></stats-item>
-          <stats-item item="[[item]]" metric="register" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
+          <template is="dom-if">
+            <stats-item item="[[item]]" metric="register" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
+          </template>
           <stats-item item="[[item]]" metric="created" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
           <stats-item item="[[item]]" metric="attached" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
           <stats-item item="[[item]]" metric="detached" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>

--- a/src/elements/stats-table/stats-table.html
+++ b/src/elements/stats-table/stats-table.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div class="header">Tag Name</div>
         <div class="header">Count</div>
         <div class="header">Total Time</div>
+        <div class="header">Register</div>
         <div class="header">Created</div>
         <div class="header">Attached</div>
         <div class="header">Detached</div>
@@ -64,6 +65,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div class="cell name">{{item.tagName}}</div>
           <div class="cell">{{item.count}}</div>
           <stats-item item="[[item]]" metric="totalTime" stats="[[stats]]" all-tags-stats="[[allTagsStats]]" class="total"></stats-item>
+          <stats-item item="[[item]]" metric="register" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
           <stats-item item="[[item]]" metric="created" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
           <stats-item item="[[item]]" metric="attached" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>
           <stats-item item="[[item]]" metric="detached" stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-item>

--- a/src/polymer-panel.html
+++ b/src/polymer-panel.html
@@ -96,6 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             tagName: 'All Custom Elements',
             count: 0,
             totalTime: 0,
+            register: 0,
             created: 0,
             attached: 0,
             detached: 0,
@@ -110,6 +111,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               tagName: tag,
               count: tagData.count,
               totalTime: 0,
+              register: (tagData.register) ? tagData.register.totalTime : 0,
               created: (tagData.created) ? tagData.created.totalTime : 0,
               attached: (tagData.attached) ? tagData.attached.totalTime : 0,
               detached: (tagData.detached) ? tagData.detached.totalTime : 0,
@@ -118,16 +120,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               data: (tagData.data) ? tagData.data.totalTime : 0,
             };
             tagStats.totalTime =
+              tagStats.register +
               tagStats.created +
               tagStats.attached +
               tagStats.detached +
               tagStats.data +
               tagStats.attributeChanged;
             displayData.push(tagStats);
-            this.maxCallbackTime = Math.max(this.maxCallbackTime, tagStats.created,
-                tagStats.attached, tagStats.detached, tagStats.attributeChanged);
+            this.maxCallbackTime = Math.max(
+                this.maxCallbackTime,
+                tagStats.register,
+                tagStats.created,
+                tagStats.attached,
+                tagStats.detached,
+                tagStats.attributeChanged);
             allTagsStats.count += tagStats.count;
             allTagsStats.totalTime += tagStats.totalTime;
+            allTagsStats.register += tagStats.register;
             allTagsStats.created += tagStats.created;
             allTagsStats.attached += tagStats.attached;
             allTagsStats.detached += tagStats.detached;

--- a/src/polymer-panel.html
+++ b/src/polymer-panel.html
@@ -63,7 +63,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </paper-button>
           </div>
           <template is="dom-if" if="{{stats}}">
-            <stats-table stats="[[stats]]" all-tags-stats="[[allTagsStats]]"></stats-table>
+            <stats-table
+                stats="[[stats]]"
+                all-tags-stats="[[allTagsStats]]"
+                show-register-column="[[showRegisterColumn]]"
+                >
+            </stats-table>
           </template>
         </paper-material>
       </template>
@@ -82,6 +87,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       allTagsStats: {
         type: Object,
       },
+
+      showRegisterColumn: Boolean,
     },
 
     attached() {
@@ -129,11 +136,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             displayData.push(tagStats);
             this.maxCallbackTime = Math.max(
                 this.maxCallbackTime,
-                tagStats.register,
                 tagStats.created,
                 tagStats.attached,
                 tagStats.detached,
                 tagStats.attributeChanged);
+            if (showRegisterColumn) {
+              this.maxCallbackTime = Math.max(
+                  this.maxCallbackTime,
+                  tagStats.register);
+            }
             allTagsStats.count += tagStats.count;
             allTagsStats.totalTime += tagStats.totalTime;
             allTagsStats.register += tagStats.register;
@@ -176,6 +187,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 })();
       </script>
     </dom-module>
-    <polymer-panel></polymer-panel>
+    <polymer-panel show-register-column="false"></polymer-panel>
   </body>
 </html>


### PR DESCRIPTION
Shows the 'register' metric from element-zones. The number provided by element-zones are not so useful because they don't yet capture Polymer() prototype setup time. See https://github.com/PolymerLabs/element-zones/issues/2
